### PR TITLE
[feat] SEO를 위한 메타 추가

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import styled from "styled-components";
 import FadeUpAnimation from "./common/FadeUpAnimation";
-import Image from "next/image";
-import { motion } from "framer-motion";
 import ImageCarousel from "./common/ImageCarousel";
 import { carouselImages } from "../assets/Works";
 import {

--- a/components/WorksDetailHeader.tsx
+++ b/components/WorksDetailHeader.tsx
@@ -34,13 +34,13 @@ const WorksTags = styled.div`
   margin: 2.5rem 0;
 `;
 
-const WorksTag = styled.p`
+const WorksTag = styled.label`
   background-color: rgb(234, 234, 234);
   font-size: 18px;
   padding: 2px 10px;
 `;
 
-const WorksDescriptionDetail = styled.p`
+const WorksDescriptionDetail = styled.label`
   font-size: 18px;
   color: rgb(11, 11, 11);
   line-height: 2;

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,13 +1,32 @@
-import { Html, Head, Main, NextScript } from 'next/document'
+import { Html, Head, Main, NextScript } from "next/document";
 
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        <title>BOLD, 스튜디오 볼드 - for new design and branding. </title>
+        <meta
+          name="description"
+          content="혁신적인 시각과 접근법으로 창의적인 솔루션을 이용한 대담한 브랜드 디자인"
+        />
+        <meta name="robots" content="noindex,nofollow" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+        <meta
+          property="og:title"
+          content="BOLD, 스튜디오 볼드 - for new design and branding."
+        />
+        <meta property="og:url" content="https://boldgobynd.vercel.app/" />
+        <meta
+          property="og:description"
+          content="혁신적인 시각과 접근법으로 창의적인 솔루션을 이용한 대담한 브랜드 디자인"
+        />
+        <meta property="og:image" content="/favicon.ico" />
+      </Head>
       <body>
         <Main />
         <NextScript />
       </body>
     </Html>
-  )
+  );
 }

--- a/pages/works/[title].tsx
+++ b/pages/works/[title].tsx
@@ -19,11 +19,13 @@ export default function WorkDetailPages({ work }: { work: Work }) {
   }
 
   return (
-    <Layout headerBgColor>
-      <WorksDetailHeader work={work} />
-      <WorksDetail work={work} />
-      <WorksDetailFooter />
-    </Layout>
+    <article>
+      <Layout headerBgColor>
+        <WorksDetailHeader work={work} />
+        <WorksDetail work={work} />
+        <WorksDetailFooter />
+      </Layout>
+    </article>
   );
 }
 


### PR DESCRIPTION
- head 태그 안에 title, meta 태그 추가
- 메타 제공 광고 폼에 맞는 property og:~인 meta 태그 추가
- WorksDetail 페이지를 <article>로 감싸 독립페이지임을 구별하도록함